### PR TITLE
fix: Prefix license key env var with NEXT_PUBLIC_

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ Install the following before starting:
 ## Setup
 
 ```bash
+# Get a Replicache license key
+npx replicache get-license
+
 git clone https://github.com/rocicorp/replicache-todo
 cd replicache-todo
 npm install
@@ -26,7 +29,7 @@ supabase start
 To run `replicache-todo` app, run the following command but substitute each angle-bracket-wrapped parameter with the corresponding value which was output from `supabase start`.
 
 ```bash
-DATABASE_URL="<DB URL>" NEXT_PUBLIC_SUPABASE_URL="<API URL>" NEXT_PUBLIC_SUPABASE_KEY="<anon key>" npm run dev
+NEXT_PUBLIC_REPLICACHE_LICENSE_KEY="<license key>" DATABASE_URL="<DB URL>" NEXT_PUBLIC_SUPABASE_URL="<API URL>" NEXT_PUBLIC_SUPABASE_KEY="<anon key>" npm run dev
 ```
 
 ## Publishing

--- a/pages/d/[id].tsx
+++ b/pages/d/[id].tsx
@@ -17,7 +17,7 @@ export default function Home() {
       const [, , spaceID] = location.pathname.split("/");
       const r = new Replicache({
         // See https://doc.replicache.dev/licensing for how to get a license key.
-        licenseKey: process.env.REPLICACHE_LICENSE_KEY!,
+        licenseKey: process.env.NEXT_PUBLIC_REPLICACHE_LICENSE_KEY!,
         pushURL: `/api/replicache-push?spaceID=${spaceID}`,
         pullURL: `/api/replicache-pull?spaceID=${spaceID}`,
         name: spaceID,


### PR DESCRIPTION
## Summary
- Prefix the license key env var with `NEXT_PUBLIC_` so it gets built into the browser payload
- Update README to reflect mandatory env var