### PR TITLE
fix: Only create a new space when assigning one in index.tsx.

### DIFF
--- a/backend/pull.ts
+++ b/backend/pull.ts
@@ -30,8 +30,6 @@ export async function pull(
 
   const [entries, lastMutationID, responseCookie] = await transact(
     async (executor) => {
-      await createDatabase(executor);
-
       return Promise.all([
         getChangedEntries(executor, spaceID, requestCookie ?? 0),
         getLastMutationID(executor, pull.clientID),
@@ -44,9 +42,13 @@ export async function pull(
   console.log("responseCookie: ", responseCookie);
   console.log("Read all objects in", Date.now() - t0);
 
+  if (responseCookie === undefined) {
+    throw new Error(`Unknown space ${spaceID}`);
+  }
+
   const resp: PullResponse = {
     lastMutationID: lastMutationID ?? 0,
-    cookie: responseCookie ?? 0,
+    cookie: responseCookie,
     patch: [],
   };
 

--- a/pages/d/[id].tsx
+++ b/pages/d/[id].tsx
@@ -3,6 +3,33 @@ import { Replicache } from "replicache";
 import { M, mutators } from "../../frontend/mutators";
 import App from "../../frontend/app";
 import Pusher from "pusher-js";
+import { GetServerSideProps } from "next";
+import { transact } from "../../backend/pg";
+import { getCookie } from "../../backend/data";
+
+export const getServerSideProps: GetServerSideProps = async (context) => {
+  const [, , spaceID] = context.resolvedUrl.split("/");
+  if (spaceID === undefined) {
+    throw new Error("Missing spaceID path component");
+  }
+
+  const cookie = await transact(async (executor) => {
+    return await getCookie(executor, spaceID);
+  });
+
+  if (cookie === undefined) {
+    return {
+      redirect: {
+        destination: `/`,
+        permanent: false,
+      },
+    };
+  }
+
+  return {
+    props: {},
+  };
+};
 
 export default function Home() {
   const [rep, setRep] = useState<Replicache<M> | null>(null);

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,14 +1,20 @@
 import { nanoid } from "nanoid";
 import { GetServerSideProps } from "next";
+import { createSpace } from "../backend/data";
+import { transact } from "../backend/pg";
 
 function Page() {
   return "";
 }
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
+  const spaceID = nanoid(6);
+  await transact(async (executor) => {
+    await createSpace(executor, spaceID);
+  });
   return {
     redirect: {
-      destination: `/d/${nanoid(6)}`,
+      destination: `/d/${spaceID}`,
       permanent: false,
     },
   };


### PR DESCRIPTION
# Problem

If you load replicache-todo into a tab, let it run, then delete the backend database, then refresh, the app gets into a weird state: new mutations are applied optimistically, but aren't replicated to other clients.

This is caused because pushing to replicache-todo implicitly creates the "space" row in the database if it doesn't exist. As a result if an app stays open with a spaceID in the URL while the db is deleted, that space is recreated with initial values (cookie: 0) when the server reboots.

From the server's point of view, the client keeps sending mutations from the future (because the client is at some lmid > 0), so the mutations are ignored. From the client's pov, the sever just never accepts any of its mutations, so it keeps trying to resend them.

If the client is refreshed, something even worse happens: a new clientID is assigned, but the cookie and old client view are kept. So now the server starts *accepting* mutations on the new space, but the cookie the client has is from the future from the server's pov. So every push is accepted, but every pull is a no-op and the old client view from before the server was rebooted remains.

# Root Cause

The core problem here is that Replicache has an invariant that servers don't go back in time. If a server serves state X with cookie C, it must never revert to an earlier state with cookie B. If this happens, existing clients who have cookie C will see mutations "disappear" because those mutations will advance the server from B->C, but when those existing clients ask for a diff from C, they will receive a no-op diff.

Because replicache-todo was implicitly creating spaces that were not known on push, deleting a space was equivalent to sending it back in time. The next push would implicitly recreate the space at the initial state.

# Solution

The solution is to stop implicitly creating spaces on push. Now they are only created when they are actually allocated in index.tsx. Push and pull now error if they receive a message for a space that doesn't exist. As a convenience for developers, [id].tsx also checks for this situation and redirects back to index.tsx if it occurs, which causes a new space to be picked.