### PR TITLE
refactor: avoid duplicate sort fields.

### DIFF
--- a/frontend/app.tsx
+++ b/frontend/app.tsx
@@ -7,15 +7,19 @@ import MainSection from "./main-section";
 import { M } from "./mutators";
 import { listTodos, TodoUpdate } from "./todo";
 
+// This is the top level React component of any interest.
 const App = ({ rep }: { rep: Replicache<M> }) => {
+  // Subscribe to all todos and sort them.
   const todos = useSubscribe(rep, listTodos, [], [rep]);
   todos.sort((a, b) => a.sort - b.sort);
 
+  // Define basic event handlers and connect them to Replicache mutators. Each
+  // of these mutators runs immediately (optimistically) locally, then runs
+  // again on the server-side automatically.
   const handleNewItem = (text: string) =>
-    rep.mutate.putTodo({
+    rep.mutate.createTodo({
       id: nanoid(),
       text,
-      sort: todos.length > 0 ? todos[todos.length - 1].sort + 1 : 0,
       completed: false,
     });
 

--- a/frontend/mutators.ts
+++ b/frontend/mutators.ts
@@ -1,9 +1,28 @@
-import { putTodo, updateTodo, deleteTodos, markTodosCompleted } from "./todo";
+// This file exports our mutators. Mutators are just JavaScript functions with
+// a special signature that are registered at construction with Replicache and
+// callable as `myReplicache.mutate.foo(args)`.
+//
+// Replicache runs each mutator optimistically on the client-side, and then
+// later re-runs it on the server-side against the canonical datastore. This
+// re-running of mutations is how Replicache handles conflicts: the mutator
+// itself can check the datastore when it runs for conflicts and do something
+// reasonable.
+//
+// In JavaScript-based Replicache apps, it's common to reuse mutator functions
+// on both client and server. This sample demonstrates the pattern by using
+// these mutators both with Replicache on the client (see /pages/[id].tsx) and
+// on the server (this file is loaded by backend/push.ts).
+import {
+  createTodo,
+  updateTodo,
+  deleteTodos,
+  markTodosCompleted,
+} from "./todo";
 
 export type M = typeof mutators;
 
 export const mutators = {
-  putTodo,
+  createTodo,
   updateTodo,
   deleteTodos,
   markTodosCompleted,

--- a/frontend/todo.ts
+++ b/frontend/todo.ts
@@ -1,13 +1,20 @@
+// This file defines the todo entity and its related operations.
+//
+// Much of this is generated using @rocicorp/rails, a helper library which can
+// generate a CRUD API for Replicache given just a type definition. See
+// https://github.com/rocicorp/rails for more information.
 import { z } from "zod";
 import { entitySchema, generate, Update } from "@rocicorp/rails";
 import { WriteTransaction } from "replicache";
 
+// Define the todo datatype.
 export const todoSchema = entitySchema.extend({
   text: z.string(),
   completed: z.boolean(),
   sort: z.number(),
 });
 
+// Generate basic CRUD API using rails.
 const {
   put: putTodo,
   update: updateTodo,
@@ -18,15 +25,37 @@ const {
 export type Todo = z.infer<typeof todoSchema>;
 export type TodoUpdate = Update<Todo>;
 
-export { putTodo, updateTodo, listTodos };
+// The generated put, update, delete, etc. functions can be used as mutators
+// directly because they have the right signature. But they also nicely compose
+// into higher-level more specialized mutators like `createTodo`, `deleteTodos`,
+// etc below.
+export { updateTodo, listTodos, createTodo, deleteTodos, markTodosCompleted };
 
-export async function deleteTodos(tx: WriteTransaction, ids: string[]) {
+// This specialized mutator creates a new todo, assigning a sort value that is
+// one higher than the current max for this space. It's important to understand
+// that this functions runs at least twice: once optimistically on the client,
+// and later on the server.
+//
+// If two clients create new todos concurrently, they both might choose the same
+// sort value. That's fine because later when the mutator re-runs on the server
+// the two todos will get unique values. Replicache will automaticall sync the
+// change back to the clients, reconcile any changes that happened client-side
+// in the meantime, and update the UI to reflect the changes.
+async function createTodo(tx: WriteTransaction, todo: Omit<Todo, "sort">) {
+  const todos = await listTodos(tx);
+  todos.sort((t1, t2) => t1.sort - t2.sort);
+
+  const maxSort = todos.pop()?.sort ?? 0;
+  await putTodo(tx, { ...todo, sort: maxSort + 1 });
+}
+
+async function deleteTodos(tx: WriteTransaction, ids: string[]) {
   for (const id of ids) {
     await deleteTodo(tx, id);
   }
 }
 
-export async function markTodosCompleted(
+async function markTodosCompleted(
   tx: WriteTransaction,
   { ids, completed }: { ids: string[]; completed: boolean }
 ) {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -7,7 +7,28 @@ function Page() {
   return "";
 }
 
-export const getServerSideProps: GetServerSideProps = async (context) => {
+// This is the entrypoint for the application. We randomly select a new "space"
+// to store todos in and create it server-side, then redirect the user to
+// /d/<spaceid>, which actually loads the app.
+//
+// Spaces are not part of the Replicache protocol officially, but they are a
+// common pattern for Replicache apps. Because server-side data a user has
+// access to is often larger than would make sense to sync all at once, an easy
+// approach in many applications is to partition the data into "spaces". Each
+// space becomes one Replicache "cache" that is synced in its entirety when
+// used. When the user moves around within the space, the ux is instant, and the
+// only progress bar is potentially when crossing spaces.
+//
+// In a real todo application, there'd likely only be need for one space, since
+// a user is not going to ever have enough todos to have to partition at all.
+// But in a sophisticated project management application, each project would
+// likely be one space.
+//
+// All our demo apps use spaces for a different reason: each navigation to the
+// demo app gets its own space so that different demoers aren't confused by
+// seeing other demoers making changes.
+export const getServerSideProps: GetServerSideProps = async () => {
+  // Create a new random space in the backend database.
   const spaceID = nanoid(6);
   await transact(async (executor) => {
     await createSpace(executor, spaceID);


### PR DESCRIPTION
Duplicate sort fields didn't matter for this demo, but it shows off more of Replicache to avoid them and it's easy enough to do.

Also add a bunch of inline documentation. We received some feedback asking for this.