### PR TITLE
Move to server-sent events + render

### DIFF
--- a/backend/pg.ts
+++ b/backend/pg.ts
@@ -14,7 +14,15 @@ const pool = (async () => {
     console.log("creating global pool");
     const pool = memdb
       ? (new (newDb().adapters.createPg().Pool)() as Pool)
-      : new Pool({ connectionString: process.env.DATABASE_URL });
+      : new Pool({
+          connectionString: process.env.DATABASE_URL,
+          ssl:
+            process.env.NODE_ENV === "production"
+              ? {
+                  rejectUnauthorized: false,
+                }
+              : undefined,
+        });
     await withExecutorAndPool(createDatabase, pool);
 
     // the pool will emit an error on behalf of any idle clients

--- a/backend/poke.ts
+++ b/backend/poke.ts
@@ -1,0 +1,43 @@
+type Listener = () => void;
+type ListenerMap = Map<string, Set<Listener>>;
+
+function getListenerMap() {
+  const global = (globalThis as unknown) as {
+    listeners: ListenerMap | undefined;
+  };
+  if (!global.listeners) {
+    global.listeners = new Map();
+  }
+  return global.listeners;
+}
+
+export function listen(spaceID: string, listener: Listener) {
+  const map = getListenerMap();
+  let set = map.get(spaceID);
+  if (!set) {
+    set = new Set();
+    map.set(spaceID, set);
+  }
+  set.add(listener);
+  return () => unlisten(spaceID, listener);
+}
+
+export function unlisten(spaceID: string, listener: Listener) {
+  const map = getListenerMap();
+  const set = map.get(spaceID);
+  if (!set) {
+    return;
+  }
+  set.delete(listener);
+}
+
+export function pokeSpace(spaceID: string) {
+  const map = getListenerMap();
+  const set = map.get(spaceID);
+  if (!set) {
+    return;
+  }
+  for (const listener of set) {
+    listener();
+  }
+}

--- a/backend/push.ts
+++ b/backend/push.ts
@@ -9,7 +9,7 @@ import { ReplicacheTransaction } from "./replicache-transaction";
 import { mutators } from "../frontend/mutators";
 import { z } from "zod";
 import { parseIfDebug } from "@rocicorp/rails";
-import Pusher from "pusher";
+import { pokeSpace } from "./poke";
 
 const mutationSchema = z.object({
   id: z.number(),
@@ -91,27 +91,7 @@ export async function push(spaceID: string, requestBody: any) {
       tx.flush(),
     ]);
 
-    if (
-      process.env.NEXT_PUBLIC_PUSHER_APP_ID &&
-      process.env.NEXT_PUBLIC_PUSHER_KEY &&
-      process.env.NEXT_PUBLIC_PUSHER_SECRET &&
-      process.env.NEXT_PUBLIC_PUSHER_CLUSTER
-    ) {
-      const startPoke = Date.now();
-
-      const pusher = new Pusher({
-        appId: process.env.NEXT_PUBLIC_PUSHER_APP_ID,
-        key: process.env.NEXT_PUBLIC_PUSHER_KEY,
-        secret: process.env.NEXT_PUBLIC_PUSHER_SECRET,
-        cluster: process.env.NEXT_PUBLIC_PUSHER_CLUSTER,
-        useTLS: true,
-      });
-
-      await pusher.trigger("default", "poke", {});
-      console.log("Poke took", Date.now() - startPoke);
-    } else {
-      console.log("Not poking because Pusher is not configured");
-    }
+    pokeSpace(spaceID);
   });
 
   console.log("Processed all mutations in", Date.now() - t0);

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,8 +28,6 @@
         "nanoid": "^3.3.1",
         "pg-mem": "^2.5.0",
         "prettier": "^2.2.1",
-        "pusher": "^5.1.0-beta",
-        "pusher-js": "^7.1.1-beta",
         "todomvc-app-css": "^2.4.2",
         "ts-node": "^10.7.0",
         "typescript": "^4.1.5",
@@ -502,18 +500,6 @@
       "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
       "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
       "dev": true
-    },
-    "node_modules/abort-controller": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-      "dev": true,
-      "dependencies": {
-        "event-target-shim": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=6.5"
-      }
     },
     "node_modules/acorn": {
       "version": "8.7.0",
@@ -1728,15 +1714,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/event-target-shim": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/events": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
@@ -2778,16 +2755,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-base64": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-base64/-/is-base64-1.1.0.tgz",
-      "integrity": "sha512-Nlhg7Z2dVC4/PTvIFkgVVNvPHSO2eR/Yd0XzhGiXCXEvWnptXlXa/clQ8aePPiMuxEGcWfzWbGw2Fe3d+Y3v1g==",
-      "dev": true,
-      "bin": {
-        "is_base64": "bin/is-base64",
-        "is-base64": "bin/is-base64"
       }
     },
     "node_modules/is-bigint": {
@@ -4870,31 +4837,6 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
       "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
     },
-    "node_modules/pusher": {
-      "version": "5.1.0-beta",
-      "resolved": "https://registry.npmjs.org/pusher/-/pusher-5.1.0-beta.tgz",
-      "integrity": "sha512-ujM7BHA77/sHdIuhAbRdWdnaY+KhSuGZg/1OVjKxiIqnTV8BgSL7+heBCtkRMF9pjvy9jElR8s0eCUlSfJ1FAg==",
-      "dev": true,
-      "dependencies": {
-        "abort-controller": "^3.0.0",
-        "is-base64": "^1.1.0",
-        "node-fetch": "^2.6.1",
-        "tweetnacl": "^1.0.0",
-        "tweetnacl-util": "^0.15.0"
-      },
-      "engines": {
-        "node": ">= 4.0.0"
-      }
-    },
-    "node_modules/pusher-js": {
-      "version": "7.1.1-beta",
-      "resolved": "https://registry.npmjs.org/pusher-js/-/pusher-js-7.1.1-beta.tgz",
-      "integrity": "sha512-4aGhQFMOfHDmlc8hOS/wYf2f7wcKGJeUGUmLq5hDjRWlwYWBErPrGoTE5OdHJY9yRIsfwcBQzibvdyEXZ5ke6g==",
-      "dev": true,
-      "dependencies": {
-        "tweetnacl": "^1.0.3"
-      }
-    },
     "node_modules/querystring": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.1.tgz",
@@ -6130,18 +6072,6 @@
       "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.1.tgz",
       "integrity": "sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw=="
     },
-    "node_modules/tweetnacl": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
-      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
-      "dev": true
-    },
-    "node_modules/tweetnacl-util": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/tweetnacl-util/-/tweetnacl-util-0.15.1.tgz",
-      "integrity": "sha512-RKJBIj8lySrShN4w6i/BonWp2Z/uxwC3h4y7xsRrpP59ZboCd0GpEVsOnMDYLMmKBpYhb5TgHzZXy7wTfYFBRw==",
-      "dev": true
-    },
     "node_modules/type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
@@ -6928,15 +6858,6 @@
       "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
       "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
       "dev": true
-    },
-    "abort-controller": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-      "dev": true,
-      "requires": {
-        "event-target-shim": "^5.0.0"
-      }
     },
     "acorn": {
       "version": "8.7.0",
@@ -7910,12 +7831,6 @@
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
     },
-    "event-target-shim": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-      "dev": true
-    },
     "events": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
@@ -8725,12 +8640,6 @@
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
       }
-    },
-    "is-base64": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-base64/-/is-base64-1.1.0.tgz",
-      "integrity": "sha512-Nlhg7Z2dVC4/PTvIFkgVVNvPHSO2eR/Yd0XzhGiXCXEvWnptXlXa/clQ8aePPiMuxEGcWfzWbGw2Fe3d+Y3v1g==",
-      "dev": true
     },
     "is-bigint": {
       "version": "1.0.3",
@@ -10270,28 +10179,6 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
       "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
     },
-    "pusher": {
-      "version": "5.1.0-beta",
-      "resolved": "https://registry.npmjs.org/pusher/-/pusher-5.1.0-beta.tgz",
-      "integrity": "sha512-ujM7BHA77/sHdIuhAbRdWdnaY+KhSuGZg/1OVjKxiIqnTV8BgSL7+heBCtkRMF9pjvy9jElR8s0eCUlSfJ1FAg==",
-      "dev": true,
-      "requires": {
-        "abort-controller": "^3.0.0",
-        "is-base64": "^1.1.0",
-        "node-fetch": "^2.6.1",
-        "tweetnacl": "^1.0.0",
-        "tweetnacl-util": "^0.15.0"
-      }
-    },
-    "pusher-js": {
-      "version": "7.1.1-beta",
-      "resolved": "https://registry.npmjs.org/pusher-js/-/pusher-js-7.1.1-beta.tgz",
-      "integrity": "sha512-4aGhQFMOfHDmlc8hOS/wYf2f7wcKGJeUGUmLq5hDjRWlwYWBErPrGoTE5OdHJY9yRIsfwcBQzibvdyEXZ5ke6g==",
-      "dev": true,
-      "requires": {
-        "tweetnacl": "^1.0.3"
-      }
-    },
     "querystring": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.1.tgz",
@@ -11223,18 +11110,6 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.1.tgz",
       "integrity": "sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw=="
-    },
-    "tweetnacl": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
-      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
-      "dev": true
-    },
-    "tweetnacl-util": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/tweetnacl-util/-/tweetnacl-util-0.15.1.tgz",
-      "integrity": "sha512-RKJBIj8lySrShN4w6i/BonWp2Z/uxwC3h4y7xsRrpP59ZboCd0GpEVsOnMDYLMmKBpYhb5TgHzZXy7wTfYFBRw==",
-      "dev": true
     },
     "type-detect": {
       "version": "4.0.8",

--- a/package.json
+++ b/package.json
@@ -30,8 +30,6 @@
     "nanoid": "^3.3.1",
     "pg-mem": "^2.5.0",
     "prettier": "^2.2.1",
-    "pusher": "^5.1.0-beta",
-    "pusher-js": "^7.1.1-beta",
     "todomvc-app-css": "^2.4.2",
     "ts-node": "^10.7.0",
     "typescript": "^4.1.5",

--- a/pages/api/replicache-poke.ts
+++ b/pages/api/replicache-poke.ts
@@ -1,0 +1,28 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { listen } from "../../backend/poke";
+
+export default async (req: NextApiRequest, res: NextApiResponse) => {
+  const spaceID = req.query["spaceID"].toString();
+
+  res.setHeader("Access-Control-Allow-Origin", "*");
+  res.setHeader("Content-Type", "text/event-stream;charset=utf-8");
+  res.setHeader("Cache-Control", "no-cache, no-transform");
+  res.setHeader("X-Accel-Buffering", "no");
+
+  res.write(`id: ${Date.now()}\n`);
+  res.write(`data: hello\n\n`);
+
+  const unlisten = listen(spaceID, () => {
+    res.write(`id: ${Date.now()}\n`);
+    res.write(`data: poke\n\n`);
+  });
+
+  setInterval(() => {
+    res.write(`id: ${Date.now()}\n`);
+    res.write(`data: beat\n\n`);
+  }, 30 * 1000);
+
+  res.on("close", () => {
+    unlisten();
+  });
+};

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,20 @@
+services:
+  - type: web
+    name: replicache-todo
+    env: node
+    region: oregon # optional (defaults to oregon)
+    plan: starter # optional (defaults to starter)
+    buildCommand: "npm install && npm run build" # optional (defaults to Dockerfile command)
+    startCommand: "npm run start"
+    numInstances: 1 # optional (defaults to 1)
+    envVars:
+      - key: NEXT_PUBLIC_REPLICACHE_LICENSE_KEY
+        value: TODO_PUT_LICENSE_KEY_HERE
+      - key: DATABASE_URL
+        fromDatabase:
+          name: replicache-todo
+          property: connectionString
+
+databases:
+  - name: replicache-todo
+    databaseName: db


### PR DESCRIPTION
Move the poke mechanism to server-sent events. This works on Heroku and Heroku-alikes, but Heroku doesn't support HTTP/2 which interacts badly with SSE:

https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events

Heroku seems to be slowly dying anyway and Render has a few more advantages:

- The render.yaml file is convenient, making it easy for people to deploy replicache-todo
- They have a US west coast DC
- https://render.com/render-vs-heroku-comparison