### PR TITLE
chore: Move custom mutator definition into mutators.ts and rewrite comments.

### DIFF
--- a/src/mutators.ts
+++ b/src/mutators.ts
@@ -1,23 +1,73 @@
-// This file exports our mutators. Mutators are just JavaScript functions with
-// a special signature that are registered at construction with Replicache and
-// callable as `myReplicache.mutate.foo(args)`.
+// This file defines our "mutators".
 //
-// Replicache runs each mutator optimistically on the client-side, and then
-// later re-runs it on the server-side against the backend datastore. This
-// re-running of mutations is how Replicache handles conflicts: the mutator
-// itself can check the datastore when it runs for conflicts and do something
-// reasonable.
+// Replicache mutators are how you change data in Replicache apps, and are the
+// key enabling idea that makes Replicache work.
+//
+// Mutators at core are just named functions with a special signature:
+//
+// type Mutator<Args, Ret> = (tx: WriteTransaction, args: Args) => Promise<Ret>;
+//
+// For example:
+// async function createTodo(tx: WriteTransaction, args: { text: string }) ...
+// is a mutator.
+//
+// Mutators are registered with Replicache at construction-time and callable
+// like `myReplicache.mutate.createTodo({text: "foo"})`.
+//
+// Replicache runs each mutation immediately (optimistically) on the client,
+// against the local cache, and then later (usually moments later) *re-runs* it
+// on the server-side against the backend datastore during sync.
+//
+// This re-running of mutations is how Replicache handles conflicts: the
+// mutators themselves defensively check the database when they run and do the
+// appropriate thing. The Replicache sync protocol ensures that the server-side
+// result takes precedence over the client-side optimistic result.
 //
 // In JavaScript-based Replicache apps, it's common to reuse mutator functions
 // on both client and server. This sample demonstrates the pattern by using
 // these mutators both with Replicache on the client (see app.tsx) and
 // on the server (see /pages/api/replicache/[op].ts).
-import { createTodo, updateTodo, deleteTodo } from "./todo";
+//
+// See https://doc.replicache.dev/how-it-works#sync-details for all the detail
+// on how Replicache syncs and resolves conflicts, but understanding that is not
+// required to get up and running.
+import { WriteTransaction } from "replicache";
+import { Todo, putTodo, updateTodo, deleteTodo, listTodos } from "./todo";
 
 export type M = typeof mutators;
 
+// We define three mutators.
+//
+// updateTodo and deleteTodo are just re-exported CRUD functions generated in
+// todo.ts.
+//
+// However, it's also possible to define specialized mutators that have more
+// interesting conflict-resolution logic. See `createTodo` below for an example
+// of that.
 export const mutators = {
-  createTodo,
   updateTodo,
   deleteTodo,
+  createTodo,
 };
+
+// This specialized mutator creates a new todo, assigning the next available
+// sort value. By implementing this in a mutator, we solve the problem of two
+// clients simultaneously choosing the same sort value.
+//
+// If two clients create new todos concurrently, they both might choose the same
+// sort value locally (optimistically). That's fine because later when the
+// mutator re-runs on the server the two todos will get unique values.
+//
+// Replicache will automatically sync the change back to the clients, reconcile
+// any changes that happened client-side in the meantime, and update the UI to
+// reflect the changes.
+export async function createTodo(
+  tx: WriteTransaction,
+  todo: Omit<Todo, "sort">
+) {
+  const todos = await listTodos(tx);
+  todos.sort((t1, t2) => t1.sort - t2.sort);
+
+  const maxSort = todos.pop()?.sort ?? 0;
+  await putTodo(tx, { ...todo, sort: maxSort + 1 });
+}

--- a/src/todo.ts
+++ b/src/todo.ts
@@ -1,58 +1,35 @@
-// This file defines our "Todo" entity and its operations.
-//
-// Much of this is generated using @rocicorp/rails, a helper library which can
-// generate a CRUD API for Replicache given just a type definition. See
-// https://github.com/rocicorp/rails for more information.
+// This file defines our "Todo" entity.
+// You will generally have one such file for each entity in your application.
 
 import { z } from "zod";
 import { entitySchema, generate, Update } from "@rocicorp/rails";
-import { WriteTransaction } from "replicache";
 
-// Define the todo datatype using the zod schema language.
-// See https://zod.dev/ for documentation.
+// We define our datatypes using https://zod.dev/. This isn't required to use
+// Replicache, but is recommended. It gets you free parsing/validation of JSON
+// into strong TypeScript types and is also used below to generate helper CRUD
+// functions.
 export const todoSchema = entitySchema.extend({
   text: z.string(),
   completed: z.boolean(),
   sort: z.number(),
 });
 
-// Generate basic CRUD API for that schema.
-const {
+// Export generated TypeScript types for use in app.
+
+// The complete Todo type as defined by `todoSchema` above.
+export type Todo = z.infer<typeof todoSchema>;
+
+// A version of the Todo type where every field except `id` is optional. Used
+// by the generated `updateTodo` function above.
+export type TodoUpdate = Update<Todo>;
+
+// We define basic typesafe CRUD helpers for reading and writing Todos to
+// Replicache using https://github.com/rocicorp/rails. Again, this is not
+// required (you can read and write directly using e.g., Replicache's lower-level
+// put() and get() APIs), but this gets you typesafety and validation.
+export const {
   put: putTodo,
   update: updateTodo,
   delete: deleteTodo,
   list: listTodos,
 } = generate("todo", todoSchema);
-
-// Export relevant TS types for use in app.
-export type Todo = z.infer<typeof todoSchema>;
-export type TodoUpdate = Update<Todo>;
-
-// The generated put, update, delete, etc. functions can be used as mutators
-// directly because they have the right signature. For simple apps, this is
-// often all you need!
-//
-// But the generated functions also nicely compose into higher-level, more
-// specialized mutators. See createTodo for an example below.
-export { createTodo, updateTodo, deleteTodo, listTodos };
-
-// This specialized mutator creates a new todo, assigning the next available
-// sort value. By implementing this in a mutator, we solve the problem of two
-// clients simultaneously choosing the same sort value.
-//
-// The way this works is that Replicache mutations run at least twice: once on
-// the client, optimistically, against the local datastore; and then once again
-// on the server against the backend datastore.
-//
-// If two clients create new todos concurrently, they both might choose the same
-// sort value locally. That's fine because later when the mutator re-runs on the
-// server the two todos will get unique values. Replicache will automatically
-// sync the change back to the clients, reconcile any changes that happened
-// client-side in the meantime, and update the UI to reflect the changes.
-async function createTodo(tx: WriteTransaction, todo: Omit<Todo, "sort">) {
-  const todos = await listTodos(tx);
-  todos.sort((t1, t2) => t1.sort - t2.sort);
-
-  const maxSort = todos.pop()?.sort ?? 0;
-  await putTodo(tx, { ...todo, sort: maxSort + 1 });
-}


### PR DESCRIPTION
I think it is more understandable if all the mutator comments and custom mutator are in the mutators file and todo.ts is just about entity definition.